### PR TITLE
Change publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,13 +20,13 @@ jobs:
         run: npm ci
 
       - name: Publish to Open VSX Registry
-        uses: hylo-lang/publish-vscode-extension@v1.0.1
+        uses: hylo-lang/publish-vscode-extension@v1.0.2
         id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
 
       - name: Publish to Visual Studio Marketplace
-        uses: hylo-lang/publish-vscode-extension@v1.0.1
+        uses: hylo-lang/publish-vscode-extension@v1.0.2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,13 +20,13 @@ jobs:
         run: npm ci
 
       - name: Publish to Open VSX Registry
-        uses: hylo-lang/publish-vscode-extension@v1.0.2
+        uses: HaaLeo/publish-vscode-extension@v2
         id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
 
       - name: Publish to Visual Studio Marketplace
-        uses: hylo-lang/publish-vscode-extension@v1.0.2
+        uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "hylo",
-  "displayName": "Hylo",
+  "displayName": "Hylo Language",
   "description": "VSCode extension for Hylo language",
   "icon": "icons/colored-dark.png",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "engines": {
     "vscode": "^1.96.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "hylo-vscode",
+  "name": "hylo",
   "displayName": "Hylo",
   "description": "VSCode extension for Hylo language",
   "icon": "icons/colored-dark.png",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "engines": {
     "vscode": "^1.96.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hylo",
   "description": "VSCode extension for Hylo language",
   "icon": "icons/colored-dark.png",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "engines": {
     "vscode": "^1.96.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mvs",
     "syntax highlighting"
   ],
-  "publisher": "hylo",
+  "publisher": "hylo-lang",
   "repository": {
     "type": "git",
     "url": "https://github.com/hylo-lang/vscode-hylo"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hylo",
   "description": "VSCode extension for Hylo language",
   "icon": "icons/colored-dark.png",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "engines": {
     "vscode": "^1.96.0"
   },


### PR DESCRIPTION
Now publishing works for both OpenVSX and VSCode Marketplace with the following id: `hylo-lang.hylo`